### PR TITLE
Fix: Use `appendChild` for compatibility with IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2
+
+Fixed a bug which prevented video widgets to render in IE11.
+
+- Closed: https://github.com/apostrophecms/apostrophe-lean-frontend/issues/2
+
 ## 2.0.1
 
 Fixed a bug that prevented editing an existing rich text widget when the module is active. Also added `apos.lean.closest`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-lean-frontend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A leaner frontend js world for ApostropheCMS 2.x. No jQuery, no lodash, no async module, etc. You still get a way to write widget players.",
   "main": "index.js",
   "scripts": {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -36,7 +36,7 @@ apos.lean.widgetPlayers['apostrophe-video'] = function(el, data, options) {
     }
     inner.removeAttribute('width');
     inner.removeAttribute('height');
-    el.append(inner);
+    el.appendChild(inner);
     // wait for CSS width to be known
     apos.lean.onReady(function() {
       // If oembed results include width and height we can get the


### PR DESCRIPTION
This is my proposed fix for https://github.com/apostrophecms/apostrophe-lean-frontend/issues/2

I went ahead and bumped the patch version as well as added an entry in the changelog. Hope that was alright and saves you some time. Thank you for considering the PR!

Closes #2 