### PR TITLE
Make lean-fronted module also push lean CSS, push configured js/css from the apostrophe-assets module by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## What does it do?
 
-A leaner frontend js world for [ApostropheCMS](https://apostrophecms.org) 2.x. No jQuery, no lodash, no async module, etc. You still get a way to write widget players, tiny workarounds for some of the silliest gaps in older browsers, and some players for standard widgets that are pushed to the browser only if you enable them.
+A leaner frontend js and css world for [ApostropheCMS](https://apostrophecms.org) 2.x. No jQuery, no lodash, no async module, etc. You still get a way to write widget players, tiny workarounds for some of the silliest gaps in older browsers, and some players for standard widgets that are pushed to the browser only if you enable them.
 
 This module is designed to be feasible for use back to the IE9 compatibility level.
 
@@ -115,6 +115,28 @@ module.exports = {
   }
 }
 ```
+## Pushing preconfigured assets from apostrophe-assets
+
+This module pushes js and css assets specified in _apostrophe-assets/index.js_ as if `when: 'lean'` is set, that results all these assets being pushed for both logged in/off ussers, unless `when` is set to a different value as in 
+```
+module.exports = {
+  jQuery: 3,
+  stylesheets: [
+    {
+      name: 'site',
+      when: 'always'
+    }
+  ],
+  scripts: [
+    {
+      name: 'site',
+      when: 'always'
+    }
+  ]
+};
+```
+
+Since no other inbuilt apostrophe styles are being pushed, the default prepackaged _public/css/site.less_ in _apostrophe-assets_ LESS transpilation will break due to the `@apos` style dependencies.
 
 ## What's it weigh on the front end?
 

--- a/lib/modules/apostrophe-lean-frontend-assets/index.js
+++ b/lib/modules/apostrophe-lean-frontend-assets/index.js
@@ -32,7 +32,7 @@ module.exports = {
           }
         }
         var relevant;
-        if (asset.type !== 'script') {
+        if (asset.type !== 'script' && asset.type !== 'stylesheet') {
           // Traditional logic
           relevant = (asset.when === 'always') || (when === 'all') || (asset.when === when);
         } else {
@@ -57,5 +57,26 @@ module.exports = {
       return results;
     };
 
+    /*
+    Override the pushConfigured so that self configured assets are always servered by the lean front-end, unless specified otherwise
+    */
+    self.pushConfigured = function() {
+      _.each(self.options.stylesheets || [], function(item) {
+        self.pushAsset('stylesheet', item.name, self.setWhenIfNotConfigured(item, 'lean'));
+      });
+      _.each(self.options.scripts || [], function(item) {
+        self.pushAsset('script', item.name, self.setWhenIfNotConfigured(item, 'lean'));
+      });
+    };
+
+    /*
+    Function for checking if 'when' attributed is set for an asset item, if not, set it to @defaultWhen
+    */
+    self.setWhenIfNotConfigured = function(item, defaultWhen){
+      if (!('when' in item)) {
+        item['when'] = defaultWhen;
+      }
+      return item;
+    }
   }
 };


### PR DESCRIPTION
A simple fix for filtering out non-lean stylesheets. I've also overridden the `pushConfigured`  function to serve configured assets from apostrophe-assets as 'lean' by default. 